### PR TITLE
feat: configure Astro with React integration and update TypeScript se…

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,9 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 
+import react from '@astrojs/react';
+
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+  integrations: [react()]
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,14 @@
 {
   "extends": "astro/tsconfigs/strict",
-  "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist"]
+  "include": [
+    ".astro/types.d.ts",
+    "**/*"
+  ],
+  "exclude": [
+    "dist"
+  ],
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react"
+  }
 }


### PR DESCRIPTION

This pull request updates the `astro.config.mjs` file to include the React integration for Astro. 

Key change:

* [`astro.config.mjs`](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fR4-R9): Added the React integration by importing `@astrojs/react` and updating the `defineConfig` function to include `integrations: [react()]`.